### PR TITLE
fix: filtering obs, lai, null files names done the wrong manner if no…

### DIFF
--- a/R/get_usms_files.R
+++ b/R/get_usms_files.R
@@ -177,7 +177,9 @@ get_usms_files <- function(workspace,
     usm_files <- usm_files[node_names %in% file_type]
 
     # Keeping usms xml files, except plant files, obs, lai, null
-    usm_files <- unique(usm_files[-grep("\\.obs|\\.lai|null", usm_files)])
+    useless_files_idx <- grep("\\.obs|\\.lai|null", usm_files)
+    if (length(useless_files_idx) > 0) usm_files <- usm_files[-useless_files_idx]
+    usm_files <- unique(usm_files)
     usm_files_path <- file.path(workspace_path, usm_files)
 
 


### PR DESCRIPTION
if all lai, obs files are not given or do not exist the files path list was containing only the sols.xml path.