### PR TITLE
improvement: error message for missing files before generating text files

### DIFF
--- a/R/gen_usms_xml2txt.R
+++ b/R/gen_usms_xml2txt.R
@@ -221,10 +221,21 @@ gen_usms_xml2txt <- function(javastics = NULL,
     lapply(all_files_list, function(x) return(all(x$all_exist))))
 
   if (!all(all_files_exist)) {
-    stop(paste(
-      "Missing files have been detected for usm(s):",
-      paste(usms_list[!all_files_exist], collapse = ", ")
-    ))
+    unknown_files <-
+      unlist(
+        lapply(all_files_list[!all_files_exist],
+               function(x) {x$paths[!x$all_exist]}),
+        use.names = FALSE
+      )
+    miss_files_mess <- paste(sprintf(fmt = "%s: %s \n", usms_list[!all_files_exist],
+                               unknown_files), collapse = "")
+
+    mess_length <- sum(nchar(miss_files_mess)) + 100L
+    if (options("warning.length")$warning.length < mess_length)
+      options(warning.length = mess_length)
+
+    stop("Missing files have been detected for usm(s):\n",
+         miss_files_mess)
   }
 
   # removing usms with missing files


### PR DESCRIPTION
added full files path regarding usms
stop message display adaptation to message length (see setting options("warning.length"))

