### PR TITLE
add missing verbose in upgrade_workspace_xml_10_11

### DIFF
--- a/R/upgrade_v10_v11.R
+++ b/R/upgrade_v10_v11.R
@@ -600,6 +600,8 @@ upgrade_usms_xml_10_11 <- function(file,
 # @param plant
 #' @param overwrite Logical TRUE for overwriting files,
 #' FALSE otherwise (default)
+#' @param verbose   logical, TRUE for displaying a copy message
+#' FALSE otherwise (default)
 #'
 #' @return None
 #'
@@ -612,7 +614,8 @@ upgrade_workspace_xml_10_11 <- function(workspace,
                                         out_dir,
                                         from_version = "V10.0",
                                         target_version = "V11.0",
-                                        overwrite = FALSE){
+                                        overwrite = FALSE,
+                                        verbose = FALSE){
 
 
   # Just in case, creating the target directory

--- a/man/upgrade_workspace_xml_10_11.Rd
+++ b/man/upgrade_workspace_xml_10_11.Rd
@@ -10,7 +10,8 @@ upgrade_workspace_xml_10_11(
   out_dir,
   from_version = "V10.0",
   target_version = "V11.0",
-  overwrite = FALSE
+  overwrite = FALSE,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -25,6 +26,9 @@ upgrade_workspace_xml_10_11(
 \item{target_version}{Target STICS version (character or numeric)}
 
 \item{overwrite}{Logical TRUE for overwriting files,
+FALSE otherwise (default)}
+
+\item{verbose}{logical, TRUE for displaying a copy message
 FALSE otherwise (default)}
 }
 \value{


### PR DESCRIPTION
# Add missing `verbose` in `upgrade_workspace_xml_10_11`

## Description

The function `upgrade_workspace_xml_10_11` calls `workspace_files_copy` with the parameter `verbose` but it does not have it itself.
I hence added it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please list or describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* R version:
* OS:
* Dependency versions (optional but recommended):

## Reviewers

I explicitly ask for reviewers whenever possible, see [the documentation](https://sticsrpacks.github.io/sandbox/articles/use-git-and-github.html#pull-request) for doing so.

## Checklist for the reviewers:

- [ ] The code follows the style guidelines of this project
- [ ] The code is commented, particularly in hard-to-understand areas
- [ ] The documentation has been updated if necessary
- [ ] The changes generate no new errors, warnings or notes during the tests (package or CRAN tests)
- [ ] New tests have been added on the package to prove the fix is effective or the new feature works
- [ ] New and existing unit tests pass locally and remotely with those changes

If this pull request add breaking changes for other SticsRPacks packages: 
- [ ] The team of the other package has been informed of the changes to come
- [ ] Another pull request has been proposed on their package to account for the potential impacts of the changes (optional)
