### PR TITLE
Fix missing space in error message

### DIFF
--- a/R/stics_files_utils.R
+++ b/R/stics_files_utils.R
@@ -63,7 +63,7 @@ get_examples_path <- function(file_type, stics_version = "latest",
   if (any(is_na_dirs))
     stop("Not any data in examples for ",
          paste(file_type[is_na_dirs], collapse = ", "),
-         "and version ", version_name)
+         " and version ", version_name)
 
   files_str <- unlist(
     lapply(file_type,


### PR DESCRIPTION
The error message

> Not any data in examples for xmland version V10.0

has me made search for a land called `xm` .. 

The correct error should be

> Not any data in examples for xml and version V10.0
