### PR TITLE
Avoid too many triggers to SticsRTest

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    #branches: [main, master]
+    branches: main
   pull_request:
-    branches: [main, master]
+    branches: main
 
 name: R-CMD-check
 


### PR DESCRIPTION
Until this point we triggered SticsRTest twice every commit in a PR because of how the yaml was written. This is now fixed. We now test every commit on the PR, and then a last time on main after merging.