### PR TITLE
Fix load obs sim

### DIFF
--- a/R/get_file.R
+++ b/R/get_file.R
@@ -32,15 +32,14 @@
 #' @noRd
 #'
 get_file <- function(
-  workspace,
-  usm_name = NULL,
-  var_list = NULL,
-  dates_list = NULL,
-  usms_filepath = NULL,
-  javastics_path = NULL,
-  verbose = TRUE,
-  type = c("sim", "obs")
-) {
+    workspace,
+    usm_name = NULL,
+    var_list = NULL,
+    dates_list = NULL,
+    usms_filepath = NULL,
+    javastics_path = NULL,
+    verbose = TRUE,
+    type = c("sim", "obs")) {
   type <- match.arg(type, c("sim", "obs"), several.ok = FALSE)
 
   usms_path <- NULL
@@ -115,15 +114,14 @@ get_file <- function(
 #' @noRd
 #'
 get_file_ <- function(
-  workspace,
-  usm_name = NULL,
-  usms_filepath = NULL,
-  var_list = NULL,
-  dates_list = NULL,
-  javastics_path = NULL,
-  verbose = TRUE,
-  type = c("sim", "obs")
-) {
+    workspace,
+    usm_name = NULL,
+    usms_filepath = NULL,
+    var_list = NULL,
+    dates_list = NULL,
+    javastics_path = NULL,
+    verbose = TRUE,
+    type = c("sim", "obs")) {
   # TODO: add checking dates_list format, or apply the used format in sim
   # data.frame
 
@@ -357,13 +355,12 @@ get_file_ <- function(
 #' @noRd
 #'
 get_file_one <- function(
-  dirpath,
-  filename,
-  p_name,
-  verbose,
-  dates_list,
-  var_list
-) {
+    dirpath,
+    filename,
+    p_name,
+    verbose,
+    dates_list,
+    var_list) {
   out <-
     get_file_int(dirpath, filename, p_name, verbose = verbose) %>%
     dplyr::select_if(function(x) {
@@ -401,12 +398,11 @@ get_file_one <- function(
 }
 
 get_file_from_usms <- function(
-  workspace,
-  usms_path,
-  type = c("sim", "obs"),
-  usm_name = NULL,
-  verbose = TRUE
-) {
+    workspace,
+    usms_path,
+    type = c("sim", "obs"),
+    usm_name = NULL,
+    verbose = TRUE) {
   # Getting usms names from the usms.xml file
   usms <- get_usms_list(file = file.path(usms_path))
 

--- a/man/download_data.Rd
+++ b/man/download_data.Rd
@@ -37,6 +37,8 @@ organization.
 # Getting data for a given example : study_case_1 and a given STICS version
 download_data(example_dirs = "study_case_1", stics_version = "V9.0")
 # raising an error instead of a message
-download_data(example_dirs = "study_case_1", stics_version = "V9.0",
-              raise_error = TRUE)
+download_data(
+  example_dirs = "study_case_1", stics_version = "V9.0",
+  raise_error = TRUE
+)
 }


### PR DESCRIPTION
- didn't work properly when no sim files in dirs using get_sim or obs files using get_obs
- fix about finding files in subdirectories if usm names not given (as sub dir names): listing sub-dirs and obs/sim files in them
- finally the sim and obs files for sole crops / intercrops work properly with a or p in usm names