### PR TITLE
Fix obs and lai files copy in `gen_usms_xml2txt`

### DIFF
--- a/R/gen_usms_xml2txt.R
+++ b/R/gen_usms_xml2txt.R
@@ -63,17 +63,18 @@
 #'
 
 gen_usms_xml2txt <- function(
-    javastics = NULL,
-    workspace = NULL,
-    out_dir = NULL,
-    usm = NULL,
-    stics_version = "latest",
-    verbose = TRUE,
-    dir_per_usm_flag = TRUE,
-    java_cmd = "java",
-    java_converter = FALSE,
-    parallel = FALSE,
-    cores = NA) {
+  javastics = NULL,
+  workspace = NULL,
+  out_dir = NULL,
+  usm = NULL,
+  stics_version = "latest",
+  verbose = TRUE,
+  dir_per_usm_flag = TRUE,
+  java_cmd = "java",
+  java_converter = FALSE,
+  parallel = FALSE,
+  cores = NA
+) {
   if (java_converter) {
     # javastics directory must be given
     if (is.null(javastics)) {


### PR DESCRIPTION
There was an error when copying obs and lai files using `gen_usms_xml2txt`: the files were not properly indexed.