### PR TITLE
Avoid reading the usms file twice in `gen_usms_xml2txt`

### DIFF
--- a/R/gen_usms_xml2txt.R
+++ b/R/gen_usms_xml2txt.R
@@ -351,7 +351,6 @@ gen_usms_xml2txt <- function(
         ))
       }
     } else {
-      usms_doc <- xmldocument(usms_file_path)
       usm_data <- get_usm_data(usms_doc, usm_name, workspace)
 
       # Getting the usm files paths


### PR DESCRIPTION
The usms file was read twice in `gen_usms_xml2txt`, here:
https://github.com/SticsRPacks/SticsRFiles/blob/2ae5b8efde7154526a3dc838c8663794a3ae55d9/R/gen_usms_xml2txt.R#L111
And on the line this PR is deleting.
