### PR TITLE
Update GitHub Actions token for repository dispatch

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Trigger
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.TRIGGER_PAT }}
+          token: ${{ secrets.STICSRPACKS_PAT }}
           repository: SticsRPacks/SticsRTests
           event-type: R-CMD-check
           client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "${{ github.event.repository.name }}"}'
@@ -84,7 +84,7 @@ jobs:
       - name: Wait for SticsRTests workflow to complete (block-and-fail)
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.TRIGGER_PAT }}
+          github-token: ${{ secrets.STICSRPACKS_PAT }}
           script: |
             const owner = 'SticsRPacks';
             const repo = 'SticsRTests';


### PR DESCRIPTION
Use organisation-level secret instead (STICSRPACKS_PAT) following Patrice's changes into the repo