### PR TITLE
Improve get_txt_generic code and remove readLines warning about missi…

### DIFF
--- a/R/get_file.R
+++ b/R/get_file.R
@@ -392,7 +392,7 @@ get_file_one <- function(
   )
 
   # to fix note, no visible binding ...
-  .SD <- NULL
+  .SD <- ..keep_cols <- NULL
 
   keep_cols <- df[, sapply(.SD, function(x) any(!is.na(x)))]
   out <- df[, ..keep_cols]


### PR DESCRIPTION
This PR improves and simplifies the code of the get_txt_generic() function.

The line params <- readLines(filepath) was triggering a warning when the last line of the file did not end with a newline.