### PR TITLE
Make integration tests visible from PR + use only @release integration on main

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,32 +14,35 @@ on:
         required: false
         default: main
         type: string
+      dependency_mode:
+        description: Ref selection mode for the other SticsRPacks packages
+        required: false
+        default: release
+        type: choice
+        options:
+          - main
+          - release
 
 permissions:
   contents: read
 
 jobs:
   integration-tests:
-    name: branch + others ${{ matrix.dependency_mode }}
+    name: branch + others ${{ github.event_name == 'workflow_dispatch' && inputs.dependency_mode || 'release' }}
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push' &&
         (
-          github.event.workflow_run.head_branch == 'main' ||
-          github.event.workflow_run.head_branch == 'master'
+          github.event.workflow_run.head_branch == 'main'
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        dependency_mode: [release]
     uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
     with:
       repo: SticsRFiles
       ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
       sha: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
-      dependency_mode: ${{ matrix.dependency_mode }}
+      dependency_mode: ${{ github.event_name == 'workflow_dispatch' && inputs.dependency_mode || 'release' }}
       sticsrtests_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.sticsrtests_ref || 'main' }}
     secrets: inherit

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,9 +1,19 @@
 name: integration-tests
+run-name: >-
+  integration-tests for ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
+  with SticsRTests@${{ github.event_name == 'workflow_dispatch' && inputs.sticsrtests_ref || 'main' }}
 
 on:
   workflow_run:
     workflows: ["R-CMD-check"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      sticsrtests_ref:
+        description: Branch, tag, or SHA of SticsRTests to run
+        required: false
+        default: main
+        type: string
 
 permissions:
   contents: read
@@ -12,19 +22,24 @@ jobs:
   integration-tests:
     name: branch + others ${{ matrix.dependency_mode }}
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
+      github.event_name == 'workflow_dispatch' ||
       (
-        github.event.workflow_run.event == 'pull_request' ||
-        github.event.workflow_run.head_branch == 'main'
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        (
+          github.event.workflow_run.head_branch == 'main' ||
+          github.event.workflow_run.head_branch == 'master'
+        )
       )
     strategy:
       fail-fast: false
       matrix:
-        dependency_mode: [main, release]
+        dependency_mode: [release]
     uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
     with:
       repo: SticsRFiles
-      ref: ${{ github.event.workflow_run.head_branch }}
-      sha: ${{ github.event.workflow_run.head_sha }}
+      ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
+      sha: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
       dependency_mode: ${{ matrix.dependency_mode }}
+      sticsrtests_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.sticsrtests_ref || 'main' }}
     secrets: inherit

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,10 +1,12 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: pull-request-checks
+run-name: pull-request-checks for ${{ github.head_ref }}
+
 on:
-  push:
+  pull_request:
     branches: [main, master]
 
-name: R-CMD-check
+permissions:
+  contents: read
 
 jobs:
   R-CMD-check:
@@ -16,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          #- { os: macos-latest, r: "release" }
           - { os: windows-latest, r: "release" }
           - {
               os: ubuntu-latest,
@@ -53,12 +54,33 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           pak-version: rc
-          # about pak-version:
-          # Ubuntu doesn't install the proper version of XML see https://github.com/r-lib/actions/issues/559. Remove when fixed.
-          # see also: https://stackoverflow.com/questions/73243945/pkgdown-action-failing-at-build-xml
           extra-packages: any::rcmdcheck
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+
+  integration-tests-main:
+    name: integration-tests (others main)
+    needs: R-CMD-check
+    uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
+    with:
+      repo: SticsRFiles
+      ref: ${{ github.head_ref }}
+      sha: ${{ github.event.pull_request.head.sha }}
+      dependency_mode: main
+      sticsrtests_ref: main
+    secrets: inherit
+
+  integration-tests-release:
+    name: integration-tests (others release)
+    needs: R-CMD-check
+    uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
+    with:
+      repo: SticsRFiles
+      ref: ${{ github.head_ref }}
+      sha: ${{ github.event.pull_request.head.sha }}
+      dependency_mode: release
+      sticsrtests_ref: main
+    secrets: inherit


### PR DESCRIPTION
Integration tests where triggered but not visible from the PR, so now we have a check for main and a check for PR that is different. The check for main only tests integrations for the release versions.